### PR TITLE
[#00] feat/server 404 page create

### DIFF
--- a/client/components/Calendar/Calendar.scss
+++ b/client/components/Calendar/Calendar.scss
@@ -6,11 +6,12 @@ $calendar-height: 604px;
 $calendar-day-bar-height: 48px;
 $box-radius: 10px;
 $item-gap: 20px;
+$calendar-margin-top: -85px;
 
 .cashbook-calendar {
   width: $calendar-width;
   height: $calendar-height;
-  margin-top: -140px;
+  margin-top: $calendar-margin-top;
 
   .calendar-day-bar {
     width: 100%;
@@ -29,7 +30,8 @@ $item-gap: 20px;
       justify-content: center;
       align-items: center;
       @include body-regular();
-      &:first-child, &:last-child {
+      &:first-child,
+      &:last-child {
         border-radius: $box-radius;
       }
     }
@@ -49,5 +51,4 @@ $item-gap: 20px;
       }
     }
   }
- 
 }

--- a/client/components/Modal/LoginModal.js
+++ b/client/components/Modal/LoginModal.js
@@ -1,7 +1,7 @@
 import Component from '@/lib/Component';
 import { MODAL_ANIMATION_TIME } from '@/util/constant';
 import github1 from '@/asset/github/github1.png';
-import { API_END_POINT, API_KEY } from '../../config';
+import { API_END_POINT, API_KEY } from '@/config';
 
 import './Modal.scss';
 

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  API_END_POINT: 'http://localhost:5000',
+  API_END_POINT: 'http://localhost:5000/api/v1',
   API_KEY: 'dabad929ed882e0eb261',
 };

--- a/client/pages/Chart/chart.scss
+++ b/client/pages/Chart/chart.scss
@@ -2,7 +2,7 @@
 @import '../../pages/size';
 
 .pie-chart-section-container {
-  margin-top: -144px;
+  margin-top: -85px;
   margin-bottom: 16px;
   width: 744px;
   min-height: 450px;

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  API_END_POINT: 'http://localhost:5000',
+  API_END_POINT: 'http://localhost:5000/api/v1',
   API_KEY: 'dabad929ed882e0eb261',
 };

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page Not Found</title>
+    <style>
+      .container {
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+      .container a {
+        text-decoration: none;
+        color: #2ac1bc;
+      }
+      .message {
+        color: #219a95;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 class="message">우아한 가계부에는 이런 페이지가 없어요.</h1>
+      <a href="/"><h3>서비스로 돌아갈래요. 클릭!</h3></a>
+    </div>
+  </body>
+</html>

--- a/server/app.js
+++ b/server/app.js
@@ -22,7 +22,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../public')));
 
-app.use('/', indexRouter);
+app.use('/api/v1', indexRouter);
 
 app.get('*', (_, res) => {
   res.sendFile('/index.html');
@@ -36,7 +36,11 @@ app.use((err, req, res, next) => {
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
   res.status(err.status || 500);
-  res.send('Server Error Occured..');
+  if (err.status === 404) {
+    res.sendFile('/404.html', { root: path.join(__dirname, '../public') });
+  } else {
+    res.send('Server Error Occured..');
+  }
 });
 
 app.listen(process.env.PORT || 5000, () => {


### PR DESCRIPTION
## 구현한 화면의 Screen Shot이 있나요? 첨부해주세요!
> 애니메이션이 중요하다면 gif로 첨부 부탁드립니다!
<img width="1107" alt="스크린샷 2021-08-06 오전 9 21 01" src="https://user-images.githubusercontent.com/32658347/128437459-da4a759a-af45-47cc-97e8-53756a3b875c.png">


## 프로젝트에서 구현한 기능을 간단하게 적어주세요!
> Issue에 등록된 Task를 참고하여 작성해주세요!

404 page를 서버에서 만들어 내려주도록 했고, api와 클라이언트가 same origin이다보니 구분해줄 필요가 있어서

api/v1 prefix를 api쪽 라우터에 추가해주어 구분하였습니다. 클라이언트단에서도 API_END_POINT를 변경하여 올바른 요청이 보내지도록 만들었습니다.

## 구현할 때 어려웠던 점은 있나요?
> 10분 이상 걸렸던 오류가 있다면 작성해주세요!

서버에서 index router와 index.html 파일을 보내주는 라우터의 순서가 잠시 헷갈렸습니다.

## 추가로 알아야 하는 사항이 있다면 작성해주세요!
> 추후 고쳤거나 Refactoring이 필요한 TODO 사항을 작성해주세요!

혹시나 API_END_POINT 변수를 사용하지 않아서 api/v1으로 요청을 보내지 못하는 경우가 있을진 모르겠지만, 오류가 있을 경우 참고하면 될 것 같습니다.